### PR TITLE
Adapt for radon with fixes

### DIFF
--- a/src/adapter/resourceProvider/basicResourceProvider.ts
+++ b/src/adapter/resourceProvider/basicResourceProvider.ts
@@ -36,6 +36,12 @@ export class BasicResourceProvider implements IResourceProvider {
     headers?: { [key: string]: string },
   ): Promise<Response<string>> {
     try {
+      // NOTE: `dataUriToBuffer` uses a JS implementation of base64 decoding, which is
+      // slower than the native implementation. This saves us a little time for large payloads.
+      const base64Data = url.split(",")[1];
+      const data = Buffer.from(base64Data, "base64")
+      const body = data.toString('utf-8');
+      return { ok: true, url, body, statusCode: 200 };
       const r = dataUriToBuffer(url);
       return { ok: true, url, body: new TextDecoder().decode(r.buffer), statusCode: 200 };
     } catch {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -931,6 +931,8 @@ export class Thread implements IVariableStoreLocationProvider {
   }
 
   private _installWasmPauseHandler(contextId: number) {
+    // No WASM in React Native, no point in doing this.
+    return undefined;
     // WASM files don't have sourcemaps and so aren't paused in the usual
     // instrumentation BP. But we do need to pause, either to figure out the WAT
     // lines or by mapping symbolicated files.
@@ -945,11 +947,11 @@ export class Thread implements IVariableStoreLocationProvider {
     // }),
     //
     // For now, overwrite WebAssembly methods in the runtime to get the same effect. This needs to be run in event new execution context:
-    return this._cdp.Runtime.evaluate({
-      expression: breakOnWasmInit.expr(),
-      silent: true,
-      contextId,
-    });
+    // this._cdp.Runtime.evaluate({
+    //   expression: breakOnWasmInit.expr(),
+    //   silent: true,
+    //   contextId,
+    // });
   }
 
   private async _executionContextDestroyed(contextId: number) {

--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -33,7 +33,8 @@ export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends N
       + '})()'
       + getSourceSuffix();
 
-    for (let retries = 0; retries < 200; retries++) {
+    // We don't need to set the environment in React Native, so let's just skip it.
+    for (let retries = 0; retries < 0; retries++) {
       const result = await cdp.Runtime.evaluate({
         contextId: 1,
         returnByValue: true,

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -517,7 +517,8 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
     cdp: Cdp.Api,
     run: IRunData<T>,
   ): Promise<IProcessTelemetry | undefined> {
-    for (let retries = 0; retries < 8; retries++) {
+    // this always fails on React Native, so we just skip it outright.
+    for (let retries = 0; retries < 0; retries++) {
       const telemetry = await cdp.Runtime.evaluate({
         contextId: 1,
         returnByValue: true,


### PR DESCRIPTION
- removes evaluate calls which always fail on Hermes/React Native
- replaces the JS implementation of base64 decoding with the node's implementation