### PR TITLE
Don't trigger getter side effects in getStringyProps

### DIFF
--- a/src/adapter/templates/getStringyProps.ts
+++ b/src/adapter/templates/getStringyProps.ts
@@ -40,7 +40,12 @@ export const getStringyProps = templateFunction(function(
     return out;
   }
 
-  for (const [key, value] of Object.entries(this)) {
+  const descriptors = Object.getOwnPropertyDescriptors(this);
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    if (!descriptor.enumerable || descriptor.get) {
+      continue;
+    }
+    const value = descriptor.value;
     if (customToString) {
       try {
         const repr = customToString.call(value, defaultPlaceholder);


### PR DESCRIPTION
This PR fixes an issue in getStringyProps method that gets sometimes called when the debugger scans the global/closure/local scopes when paused in order to show the list of the available properties for objects in the scope.

The issue was that the method would call `Object.entries` on the provided scope object (in the code it is referred to as `this`). The reason with `Object.entries` is that it gets a list of key / value pairs of all enumerable properties of an object. In particular, when properties are defined "lazily" using getters, those will be evaluated as well via the `Object.entries` call.

Apparently, this is undesirable, as getters can have side-effects, and in particular it is common in React Native that they tend to be used to lazily load modules (i.e. we have `require` calls in getters).

As a consequence, because of the `Object.entries` call, when debugger is paused, we'd end up resolving all the lazy values for all objects in current and global scope.

This is definitely undesirable and the proposed fix is to skip processing objects with getters in that method. We do that by using `getOwnPropertyDescriptor` and skipping entries that aren't enumerable (because `Objects.entries` would skip them either way) and also objects with getters (we detect that based on the presence of `get` method in the descriptor.

This PR does appear to fix the unintentional side-effect triggers while it doesn't appear to have any effect on how the props are presented in the debugger. The code that calls into `getStringyProps` is from `variableStore.ts` which also seems to list separately objects with "accessor props". The "lazy" objects before and after this change are presented the same and are denoted with an icon indicating that they have a getter.
