### PR TITLE
Fix breakpoints on realod

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,6 @@
   "editor.formatOnSave": true,
   "typescript.tsserver.experimental.enableProjectDiagnostics": true,
   "[typescript]": {
-    "editor.defaultFormatter": "dprint.dprint"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -610,17 +610,6 @@ export class BreakpointManager {
       return { breakpoints: [] };
     }
 
-    // If source is modified, return fake breakpoints, but don't enable/disable in runtime
-    if (params.sourceModified) {
-      return {
-        breakpoints: (params.breakpoints ?? []).map((_, i) => ({
-          id: ids[i],
-          verified: true,
-          message: 'Breakpoint set in a modified source',
-        })),
-      };
-    }
-
     // Ignore no-op breakpoint sets. These can come in from VS Code at the start
     // of the session (if a file only has disabled breakpoints) and make it look
     // like the user had removed all breakpoints they previously set, causing
@@ -637,6 +626,17 @@ export class BreakpointManager {
         return b.disable();
       }),
     );
+
+    // If source is modified, return fake breakpoints, but don't enable/disable in runtime
+    if (params.sourceModified) {
+      return {
+        breakpoints: (params.breakpoints ?? []).map((_, i) => ({
+          id: ids[i],
+          verified: false,
+          message: 'Breakpoint set in a modified source',
+        })),
+      };
+    }
 
     this._totalBreakpointsCount += result.new.length;
 

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -598,8 +598,8 @@ export class BreakpointManager {
       params.source.sourceReference
         ? this._byRef.get(params.source.sourceReference)
         : params.source.path
-        ? this._byPath.get(params.source.path)
-        : undefined;
+          ? this._byPath.get(params.source.path)
+          : undefined;
 
     const result = mergeInto(getCurrent() ?? []);
     if (params.source.sourceReference) {
@@ -608,6 +608,17 @@ export class BreakpointManager {
       this._byPath.set(params.source.path, result.list);
     } else {
       return { breakpoints: [] };
+    }
+
+    // If source is modified, return fake breakpoints, but don't enable/disable in runtime
+    if (params.sourceModified) {
+      return {
+        breakpoints: (params.breakpoints ?? []).map((_, i) => ({
+          id: ids[i],
+          verified: false,
+          message: 'Unbound breakpoint (source modified)',
+        })),
+      };
     }
 
     // Ignore no-op breakpoint sets. These can come in from VS Code at the start

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -615,8 +615,8 @@ export class BreakpointManager {
       return {
         breakpoints: (params.breakpoints ?? []).map((_, i) => ({
           id: ids[i],
-          verified: false,
-          message: 'Unbound breakpoint (source modified)',
+          verified: true,
+          message: 'Breakpoint set in a modified source',
         })),
       };
     }

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -60,7 +60,7 @@ export class ExecutionContext {
   /** Script ID paused in after WASM is initialized, from {@link breakOnWasmInit} */
   public breakOnWasmScriptId?: string;
 
-  constructor(public readonly description: Cdp.Runtime.ExecutionContextDescription) {}
+  constructor(public readonly description: Cdp.Runtime.ExecutionContextDescription) { }
 
   get isDefault(): boolean {
     return this.description.auxData && this.description.auxData['isDefault'];
@@ -100,7 +100,7 @@ export type RawLocation = {
 class DeferredContainer<T> {
   private _dapDeferred: IDeferred<T> = getDeferred();
 
-  constructor(private readonly _obj: T) {}
+  constructor(private readonly _obj: T) { }
 
   resolve(): void {
     this._dapDeferred.resolve(this._obj);
@@ -122,8 +122,7 @@ const sourcesEqual = (a: Dap.Source, b: Dap.Source) =>
   && urlUtils.comparePathsWithoutCasing(a.path || '', b.path || '');
 
 const getReplSourceSuffix = () =>
-  `\n//# sourceURL=eval-${
-    randomBytes(4).toString('hex')
+  `\n//# sourceURL=eval-${randomBytes(4).toString('hex')
   }${sourceUtils.SourceConstants.ReplExtension}\n`;
 
 /** Auxillary data present in Cdp.Debugger.Paused events in recent Chrome versions */
@@ -1140,7 +1139,7 @@ export class Thread implements IVariableStoreLocationProvider {
       case StepDirection.Over:
         return this.stepOver();
       default:
-        // continue
+      // continue
     }
 
     this._waitingForStepIn = undefined;
@@ -1747,6 +1746,14 @@ export class Thread implements IVariableStoreLocationProvider {
     executionContext.scripts.push(script);
 
     this._sourceContainer.addScriptById(script);
+
+    script.source.then(async _ => {
+      for (const breakpoints of this._breakpointManager.appliedByPath.values()) {
+        for (const bp of breakpoints) {
+          await bp.enable(this);
+        }
+      }
+    });
 
     if (event.sourceMapURL || event.scriptLanguage === 'WebAssembly') {
       // If we won't pause before executing this script, still try to load source

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1751,6 +1751,7 @@ export class Thread implements IVariableStoreLocationProvider {
       for (const breakpoints of this._breakpointManager.appliedByPath.values()) {
         for (const bp of breakpoints) {
           await bp.enable(this);
+          await this._breakpointManager.notifyBreakpointChange(bp, true);
         }
       }
     });


### PR DESCRIPTION
This PR fixes an issue with breakpoints being set on old scripts if debugger was paused during hot module reload. 

To solve this issue we "fake" that we set the breakpoints before the `scriptParsed` event was sent and only enable them after this event. 

