### PR TITLE
Comment out implementation of ScriptSkipper.initializeSkippingValueForSource as it slows down the debugger startup significanly

### DIFF
--- a/src/adapter/scriptSkipper/implementation.ts
+++ b/src/adapter/scriptSkipper/implementation.ts
@@ -281,6 +281,7 @@ export class ScriptSkipper implements IScriptSkipper, IDisposable {
     // this._initializeSkippingValueForSource(source);
   }
 
+  // @ts-ignore
   private _initializeSkippingValueForSource(source: Source, scripts = source.scripts) {
     const url = source.url;
     let skipped = this.isScriptSkipped(url);

--- a/src/adapter/scriptSkipper/implementation.ts
+++ b/src/adapter/scriptSkipper/implementation.ts
@@ -263,7 +263,22 @@ export class ScriptSkipper implements IScriptSkipper, IDisposable {
   }
 
   public initializeSkippingValueForSource(source: Source) {
-    this._initializeSkippingValueForSource(source);
+    // this is a workaround for a general sloweness of the skipping logic, in a lot of
+    // setups we want to for example exclude whole node_modules directories. The way
+    // file skipper works, is that it looks up generated source file ranges that match
+    // the pattern. For node_modules this ends up being a lot of ranges that need to be
+    // excluded. For the found ranges, it then calls Debugger.setBlackboxedRanges, which
+    // a) are not supported by hermes and even if they were, the sheer volume of ranges
+    // just makes the initialization process take too much time.
+    // Despite this being commented out, the whole skipping mechanism still works correctly.
+    // The reason is that the debugger still implements a fallback mechanism when the debugger
+    // may pause on skipped files. This is needed, as setting blackboxed ranges is async and
+    // so it needs to handle the case where ranges are set only after the debugger has paused.
+    // To read more about thie mechanism check comment in exceptionPauseService.ts before
+    // shouldScriptSkip method.
+    // Beside that, the skipping mechanism is also used for filtering console log stack traces,
+    // in which case it doesn't rely on blackboxed ranges at all.
+    // this._initializeSkippingValueForSource(source);
   }
 
   private _initializeSkippingValueForSource(source: Source, scripts = source.scripts) {


### PR DESCRIPTION
Currently, we cannot use `skipFiles` option, as it significanly impacts debugger startup performance.

After investigating this issue, it turned out that the reason lays in the fact that the skipping mechanism translates into the CDP Debugger.setBlackboxedRanges calls.

For example, when we want to file-skip all node_modules. The debugger implementation would scan over all the sources and calculate all the generated source ranges that contain files from node_modules. The number of resulting ranges is going to be close to the number of files from node_modules that are incorporated into the bundle. Selecting those ranges not only takes a lot of time, but also generates a lot of useless `setBlackboxedRanges` calls that aren't event supported by the hermes engine (marked as "experimental" in CDP spec: https://chromedevtools.github.io/devtools-protocol/tot/Debugger/#method-setBlackboxPatterns).

it turns out that this mechanism isn't even needed, because the debugger already has a fallback for the case blackboxed ranges aren't supported, or, since the calls are async, for the case when debugger is paused before the ranges are properly applied. The fallback simply checks the stack upon pause and automatically resumes the debugger if it paused at the skipped source. See this comment for more information about it: https://github.com/microsoft/vscode-js-debug/blob/e48cf24bf2d7ca773270bad01716a68fa3a8518a/src/adapter/exceptionPauseService.ts#L178

On top of that, the skip files are also used to filter out stack traces for console log calls. However, in that case the blackboxed sources aren't used either and instead the print logic iterates over stack entries and checks if they are skipped or not (see https://github.com/microsoft/vscode-js-debug/blob/e48cf24bf2d7ca773270bad01716a68fa3a8518a/src/adapter/console/textualMessage.ts#L56)




