### PR TITLE
fix: step over not working properly after moving skipfiles responsibility form proxy to js-debug

### DIFF
--- a/src/adapter/smartStepping.ts
+++ b/src/adapter/smartStepping.ts
@@ -42,7 +42,7 @@ export async function shouldStepOverStackFrame(
 
 const neverStepReasons: ReadonlySet<PausedReason> = new Set(['breakpoint', 'exception', 'entry']);
 
-const smartStepBackoutThreshold = 256;
+const smartStepBackoutThreshold = 1;
 
 /**
  * The SmartStepper is a device that controls stepping through code that lacks


### PR DESCRIPTION
This PR reduces a number of steps the debugger might through the skiped file before steping out of it. As it turns out this provides a better experience to the react native (and probably react in general) developer as a lot of dependencies do not come back to the user defined code at all.