### PR TITLE
Fix: Send origin when creating debugger connection 

### DIFF
--- a/src/cdp/webSocketTransport.ts
+++ b/src/cdp/webSocketTransport.ts
@@ -35,8 +35,13 @@ export class WebSocketTransport implements ITransport {
     while (true) {
       const dontRetryBefore = Date.now() + maxRetryInterval;
       try {
+        const parsedUrl = new URL(url);
+        const httpScheme = parsedUrl.protocol === 'wss:' ? 'https' : 'http';
         const options = {
-          headers: { host: remoteHostHeader ?? 'localhost' },
+          headers: {
+            host: remoteHostHeader ?? 'localhost',
+            Origin: `${httpScheme}://${parsedUrl.host}`,
+          },
           perMessageDeflate: false,
           maxPayload: 256 * 1024 * 1024, // 256Mb
           rejectUnauthorized: !(isSecure && targetAddressIsLoopback),


### PR DESCRIPTION
This is needed because debugger dev-middleware validates origin on connection 
https://github.com/facebook/react-native/commit/3c7b4881dde4cb417bedea7f3c28aa98c3500c13#diff-fb7f439d9397e1d41b3d1c8cdc5d5ad52d92c8ef1da587b342726109d27191ea